### PR TITLE
Add message anchor: &incompatible

### DIFF
--- a/prelude.yaml
+++ b/prelude.yaml
@@ -1931,6 +1931,18 @@ common:
         text: '强烈建议不要使用包含已删除navmeshes的mod，因为它们会导致崩溃。**已删除navmeshes**必须手动修正(一个复杂的过程，应该由mod作者完成)。更多关于**已删除navmeshes**的信息已提供[这里](https://www.creationkit.com/index.php?title=Fixing_Navmesh_Deletion_Tutorial)。'
 
 ##### Global Anchors #####
+  - &incompatible
+    type: error
+    content:
+      - lang: en
+        text: '{0} is incompatible with {1}, but both are present.'
+      - lang: de
+        text: '{0} ist inkompatibel mit {1}, aber beide sind vorhanden.'
+    subs:
+      - 'non-plugin mod 0'
+      - 'non-plugin mod 1'
+    condition: 'file("NVSE/Plugins/0.dll") and file("NVSE/Plugins/1.dll")'
+
   - &latestLOOTThread
     type: say
     content:


### PR DESCRIPTION
Under https://github.com/loot/falloutnv/issues/352

For reference, the new message anchor is a generalized version of the incompatible `inc` message that is part of the LOOT application itself. Here are the translations of that message:

```
English en
This plugin is incompatible with "{0}", but both are present.

Bulgarian bg
Тази приставка не е съвместима с „{0}“, но и двете са налични.

Danish da
Dette plugin er ikke inkompatibelt med “{0}”, men begge filer er til stede.

German de
Dieses Plugin ist inkompatibel mit "{0}", aber beide sind vorhanden.

Spanish es
Este plugin es incompatible con "{0}", pero ambos se encuentran presentes.

Finnish fi
Tämä lisäosa ei ole yhteensopiva lisäosan {0} kanssa, mutta molemmat löydettiin.

French fr
Ce plugin est incompatible avec "{0}", mais les deux sont présents.

Italian it
Questo plugin è incompatibile con "{0}", ma entrambi i file sono presenti.

Japanese jp
このプラグインと互換性のない "{0}" があります。

Korean ko
이 플러그인은 "{0}"와 호환되지 않지만 둘 다 존재합니다.

Polish pl
Ta wtyczka jest niekompatybilna z "{0}" , a jest aktywna.

Brazilian Portuguese pt_BR
Este plugin é incompatível com "{0}", mas ambos estão presentes.

Portuguese pt_PT
Este plugin é incompatível com "{0}", mas ambos os ficheiros estão presentes.

Russian ru
Этот плагин несовместим с «{0}», но оба они присутствуют.

Swedish sv
Denna insticksmodul är inkompatibel med "{0}", men bägge finns installerade.

Ukrainian uk_UA
Цей плагін несумісний з "{0}", але обидва файли присутні.

Chinese (Simplified) zh_CN
这个插件与"{0}"不兼容，但是两者都存在。
```